### PR TITLE
Use a unique queue per sidekiq instance and only process from that queue.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     diff-lcs (1.3)
+    method_source (0.9.0)
     mock_redis (0.18.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (1.6.8)
     rack-protection (1.5.3)
       rack
@@ -28,6 +33,9 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
+    rspec-sidekiq (3.0.3)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.7.1)
     sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
@@ -41,9 +49,11 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.16)
   mock_redis
+  pry
   rake (~> 10.0)
   rspec (~> 3.0)
+  rspec-sidekiq (~> 3.0)
   sidekiq_alive!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     sidekiq_alive (0.1.0)
       sidekiq
+      sinatra
 
 GEM
   remote: https://rubygems.org/
@@ -19,6 +20,8 @@ GEM
     rack (1.6.8)
     rack-protection (1.5.3)
       rack
+    rack-test (1.0.0)
+      rack (>= 1.0, < 3)
     rake (10.5.0)
     redis (3.3.5)
     rspec (3.7.0)
@@ -42,6 +45,11 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.8)
 
 PLATFORMS
   ruby
@@ -50,6 +58,7 @@ DEPENDENCIES
   bundler (~> 1.16)
   mock_redis
   pry
+  rack-test
   rake (~> 10.0)
   rspec (~> 3.0)
   rspec-sidekiq (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # SidekiqAlive
 
-SidekiqAlive offers a solution to add liveness probe for a Sidekiq instance deployed in Kubernetes.
+SidekiqAlive offers a solution to add liveness probe for Sidekiq instances deployed in Kubernetes.
 
 __How?__
 
 A http server is started and on each requests validates that a liveness key is stored in Redis. If it is there means is working.
 
-A Sidekiq job is the responsable to storing this key. If Sidekiq stops processing jobs
+A Sidekiq job is the responsible for storing this key. If Sidekiq stops processing jobs
 this key gets expired by Redis an consequently the http server will return a 500 error.
 
-This Job is responsible to requeue itself for the next liveness probe.
+Each sidekiq instance is configured to have a unique queue that ensures that its `SidekiqAlive::Worker` only process
+jobs for its instance.
 
+This Job is responsible to requeue itself for the next liveness probe.
 
 ## Installation
 
@@ -30,6 +32,18 @@ Or install it yourself as:
 
 ## Usage
 
+### Update sidekiq.yml
+A queue for each instance should be created, add the following to your processing queues in `sidekiq.yml`, you need to
+configure the `queue_name` on SidekiqAlive to match.
+
+```yaml
+  :queues:
+    - ['unique_name_for_this_instances_alive_queue', 10]
+    - [high, 10]
+    - [default, 5]
+    - [low, 1]
+```
+
 ### start the server
 
 rails example:
@@ -37,7 +51,7 @@ rails example:
 `config/initializers/sidekiq.rb`
 
 ```ruby
-SidekiqAlive..start
+SidekiqAlive.start
 ```
 
 ### Run the job for first time
@@ -49,7 +63,7 @@ rails example:
 ```
 $ bundle exec rails console
 
-#=> SidekiqAlive.perform_now
+#=> SidekiqAlive::Worker.perform
 ```
 
 ### Kubernetes setup
@@ -107,6 +121,12 @@ SidekiqAlive.setup do |config|
   # default: "SIDEKIQ::LIVENESS_PROBE_TIMESTAMP"
   #
   #   config.liveness_key = "SIDEKIQ::LIVENESS_PROBE_TIMESTAMP"
+
+  # ==> Queue to process
+  # The queue that this sidekiq instance will process, should be unique per instance
+  # default: "default"
+  #
+  #   config.queue_name = "unique_name_for_this_instances_alive_queues"
 
   # ==> Time to live
   # Time for the key to be kept by Redis.

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -1,20 +1,22 @@
+require "sidekiq"
+require "singleton"
 require "sidekiq_alive/version"
-require 'sidekiq'
-require 'pry'
+require "sidekiq_alive/config"
 
 module SidekiqAlive
   def self.start
     Sidekiq.configure_server do |config|
       config.on(:startup) do
+        SidekiqAlive::Worker.set(queue: SidekiqAlive.config.queue_with_variant).perform_async
         SidekiqAlive::Server.start
       end
     end
   end
 
   def self.store_alive_key
-    redis.set(liveness_key,
+    redis.set(config.liveness_key,
               Time.now.to_i,
-              { ex: time_to_live.to_i })
+              { ex: config.time_to_live.to_i })
   end
 
   def self.redis
@@ -22,68 +24,19 @@ module SidekiqAlive
   end
 
   def self.alive?
-    redis.ttl(liveness_key) == -2 ? false : true
-  end
-
-  def self.queue_with_variant
-    "#{queue_name}-#{queue_variant}"
+    redis.ttl(config.liveness_key) == -2 ? false : true
   end
 
   # CONFIG ---------------------------------------
 
   def self.setup
-    yield(self)
+    yield(config)
   end
 
-  def self.port=(port)
-    @port = port
+  def self.config
+    @config ||= SidekiqAlive::Config.instance
   end
-
-  def self.port
-    @port || 7433
-  end
-
-  def self.queue_name=(queue_name)
-    @queue_name = queue_name.to_s
-  end
-
-  def self.queue_variant=(variant)
-    @queue_variant = variant.to_s
-  end
-
-  def self.queue_name
-    @queue_name || "default"
-  end
-
-  def self.queue_variant
-    @queue_variant ||= Time.now.to_i.to_s
-  end
-
-  def self.liveness_key=(key)
-    @liveness_key = key
-  end
-
-  def self.liveness_key
-    @liveness_key || "SIDEKIQ::LIVENESS_PROBE_TIMESTAMP"
-  end
-
-  def self.time_to_live=(time)
-    @time_to_live = time
-  end
-
-  def self.time_to_live
-    @time_to_live || 10 * 60
-  end
-
-  def self.callback=(block)
-    @after_storing_key = block
-  end
-
-  def self.callback
-    @after_storing_key || proc {} # do nothing
-  end
-
 end
 
-require 'sidekiq_alive/server'
-require 'sidekiq_alive/worker'
+require "sidekiq_alive/worker"
+require "sidekiq_alive/server"

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -7,7 +7,6 @@ module SidekiqAlive
   def self.start
     Sidekiq.configure_server do |config|
       config.on(:startup) do
-        SidekiqAlive::Worker.set(queue: SidekiqAlive.config.queue_with_variant).perform_async
         SidekiqAlive::Server.start
       end
     end

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -1,5 +1,6 @@
 require "sidekiq_alive/version"
 require 'sidekiq'
+require 'pry'
 
 module SidekiqAlive
   def self.start
@@ -36,6 +37,14 @@ module SidekiqAlive
 
   def self.port
     @port || 7433
+  end
+
+  def self.queue_name=(queue_name)
+    @queue_name = queue_name
+  end
+
+  def self.queue_name
+    @queue_name || "default"
   end
 
   def self.liveness_key=(key)

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -25,6 +25,10 @@ module SidekiqAlive
     redis.ttl(liveness_key) == -2 ? false : true
   end
 
+  def self.queue_with_variant
+    "#{queue_name}-#{queue_variant}"
+  end
+
   # CONFIG ---------------------------------------
 
   def self.setup
@@ -40,11 +44,19 @@ module SidekiqAlive
   end
 
   def self.queue_name=(queue_name)
-    @queue_name = queue_name
+    @queue_name = queue_name.to_s
+  end
+
+  def self.queue_variant=(variant)
+    @queue_variant = variant.to_s
   end
 
   def self.queue_name
     @queue_name || "default"
+  end
+
+  def self.queue_variant
+    @queue_variant ||= Time.now.to_i.to_s
   end
 
   def self.liveness_key=(key)

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -1,0 +1,20 @@
+module SidekiqAlive
+  class Config
+    include Singleton
+
+    attr_accessor :port, :queue_name, :queue_variant, :liveness_key, :time_to_live, :callback
+
+    def initialize
+      @port = 7433
+      @queue_name = 'default'
+      @queue_variant = Time.now.to_i
+      @liveness_key = 'SIDEKIQ::LIVENESS_PROBE_TIMESTAMP'
+      @time_to_live = 10 * 60
+      @callback = proc {}
+    end
+
+    def queue_with_variant
+      "#{queue_name}-#{queue_variant}"
+    end
+  end
+end

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -2,12 +2,13 @@ module SidekiqAlive
   class Config
     include Singleton
 
-    attr_accessor :port, :queue_name, :queue_variant, :liveness_key, :time_to_live, :callback
+    attr_accessor :port, :liveness_key, :time_to_live, :callback
+    attr_reader :queue_name, :queue_variant
 
     def initialize
       @port = 7433
-      @queue_name = 'default'
-      @queue_variant = Time.now.to_i
+      @queue_name = 'sidekiq_alive'
+      @queue_variant = `hostname`.strip
       @liveness_key = 'SIDEKIQ::LIVENESS_PROBE_TIMESTAMP'
       @time_to_live = 10 * 60
       @callback = proc {}

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -1,46 +1,33 @@
+require "sinatra/base"
+require_relative "./config"
 module SidekiqAlive
-  module Server
-    def self.start
-      require 'socket'
-      Sidekiq::Logging.logger.info "Starting liveness server on #{config.port}"
-      store_alive_key # initial livenessProbe to avoid to kill the instance before it triggers the first liveness
+  class Server < Sinatra::Base
+    set :bind, '0.0.0.0'
 
-      # Start Server
-      Thread.start do
-        server = TCPServer.new('0.0.0.0', config.port)
-        loop do
-          Thread.start(server.accept) do |socket|
-            request = socket.gets # Read the first line of the request (the Request-Line)
-            if config.alive?
-              status = "200 OK"
-              response = "Alive!\n"
-            else
-              status = "500 ERROR"
-              response = "Looks like sidekiq is not working\n"
-              Sidekiq::Logging.logger.error response
-            end
-            socket.print "HTTP/1.1 #{status}\r\n" +
-                             "Content-Type: text/plain\r\n" +
-                             "Content-Length: #{response.bytesize}\r\n" +
-                             "Connection: close\r\n"
-            socket.print "\r\n" # blank line separates the header from the body, as required by the protocol
-            socket.print response
-            socket.close
-          end
-        end
+    class << self
+      def start
+        Sidekiq::Logging.logger.info "Writing SidekiqAlive alive key in redis: #{SidekiqAlive.config.liveness_key}"
+        SidekiqAlive.store_alive_key
+        set :port, SidekiqAlive.config.port
+        Thread.start { run! }
+      end
+
+      def quit!
+        super
+        exit
       end
     end
 
-    def self.config
-      SidekiqAlive
+    get '/' do
+      if SidekiqAlive.alive?
+        status 200
+        body "Alive!"
+      else
+        response = "Can't find the alive key"
+        Sidekiq::Logging.logger.error(response)
+        status 404
+        body response
+      end
     end
-
-    def self.store_alive_key
-      Sidekiq::Logging.logger.info "Writing Startup alive key in redis: #{config.liveness_key}"
-      # TODO run worker unless one already enqueued
-      config.store_alive_key
-    end
-
-
   end
 end

--- a/lib/sidekiq_alive/worker.rb
+++ b/lib/sidekiq_alive/worker.rb
@@ -2,7 +2,7 @@ require "sidekiq/api"
 module SidekiqAlive
   class Worker
     include Sidekiq::Worker
-    sidekiq_options retry: false
+    sidekiq_options retry: false, queue: SidekiqAlive.config.queue_with_variant
 
     def perform
       write_living_probe

--- a/lib/sidekiq_alive/worker.rb
+++ b/lib/sidekiq_alive/worker.rb
@@ -1,11 +1,19 @@
+require "sidekiq/api"
 module SidekiqAlive
   class Worker
     include Sidekiq::Worker
-    sidekiq_options retry: false, queue: SidekiqAlive.queue_name
+    sidekiq_options retry: false, queue: SidekiqAlive.queue_with_variant
 
     def perform
       write_living_probe
-      Sidekiq::Client.enqueue_to_in(SidekiqAlive.queue_name, SidekiqAlive.time_to_live / 2, self.class)
+      clean_old_queues
+      Sidekiq::Client.enqueue_to_in(SidekiqAlive.queue_with_variant, SidekiqAlive.time_to_live / 2, self.class)
+    end
+
+    def clean_old_queues
+      Sidekiq::Queue.all.each do |queue|
+        queue.clear if queue.name =~ /#{SidekiqAlive.queue_name}/ && queue.latency > SidekiqAlive.time_to_live
+      end
     end
 
     def write_living_probe

--- a/lib/sidekiq_alive/worker.rb
+++ b/lib/sidekiq_alive/worker.rb
@@ -1,11 +1,11 @@
 module SidekiqAlive
   class Worker
     include Sidekiq::Worker
-    sidekiq_options retry: false
+    sidekiq_options retry: false, queue: SidekiqAlive.queue_name
 
     def perform
       write_living_probe
-      self.class.perform_in(SidekiqAlive.time_to_live / 2)
+      Sidekiq::Client.enqueue_to_in(SidekiqAlive.queue_name, SidekiqAlive.time_to_live / 2, self.class)
     end
 
     def write_living_probe

--- a/sidekiq_alive.gemspec
+++ b/sidekiq_alive.gemspec
@@ -33,8 +33,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec-sidekiq", "~> 3.0"
   spec.add_development_dependency "mock_redis"
   spec.add_development_dependency "pry"
   spec.add_dependency "sidekiq"
+  spec.add_dependency "sinatra"
 end

--- a/sidekiq_alive.gemspec
+++ b/sidekiq_alive.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec-sidekiq", "~> 3.0"
   spec.add_development_dependency "mock_redis"
+  spec.add_development_dependency "pry"
   spec.add_dependency "sidekiq"
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,17 +1,33 @@
-require 'net/http'
+require 'rack/test'
 RSpec.describe SidekiqAlive::Server do
-  let(:uri) { URI("http://localhost:#{SidekiqAlive.port}") }
-  subject(:response) { Net::HTTP.get_response(uri) }
+  include Rack::Test::Methods
 
-  it 'accepts requests' do
-    expect(response.code).to eq '200'
-    expect(response.message).to eq("OK")
-    expect(response.body).to match("Alive!")
+  subject(:app) { described_class }
+
+  describe 'responses' do
+    it "responds with success when the service is alive" do
+      allow(SidekiqAlive).to receive(:alive?) { true }
+      get '/'
+      expect(last_response).to be_ok
+      expect(last_response.body).to eq('Alive!')
+    end
+
+    it "responds with an error when the service is not alive" do
+      allow(SidekiqAlive).to receive(:alive?) { false }
+      get '/'
+      expect(last_response).not_to be_ok
+      expect(last_response.body).to eq("Can't find the alive key")
+    end
   end
 
-  it "when key is removed form redis should return error" do
-    SidekiqAlive.redis.del(SidekiqAlive.liveness_key)
-    expect(response.code).to eq '500'
-    expect(response.message).to eq("ERROR")
+  describe '.start' do
+    it 'logs the setup and then stores the alive key before supering' do
+      expect(Sidekiq::Logging.logger).to receive(:info).with(match(/Writing SidekiqAlive alive key in redis:/))
+      expect(SidekiqAlive).to receive(:store_alive_key)
+      expect(Thread).to receive(:start).and_yield
+      expect(described_class).to receive(:run!)
+
+      described_class.start
+    end
   end
 end

--- a/spec/sidekiq_alive_spec.rb
+++ b/spec/sidekiq_alive_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SidekiqAlive do
   end
 
   it 'configurations behave as expected' do
-    k = described_class
+    k = described_class.config
     expect(k.port).to eq 7433
     k.port = 4567
     expect(k.port).to eq 4567
@@ -29,9 +29,9 @@ RSpec.describe SidekiqAlive do
 
   it '::store_alive_key" stores key with the expected ttl' do
     redis = SidekiqAlive.redis
-    expect(redis.ttl(SidekiqAlive.liveness_key)).to eq -2
+    expect(redis.ttl(SidekiqAlive.config.liveness_key)).to eq -2
     SidekiqAlive.store_alive_key
-    expect(redis.ttl(SidekiqAlive.liveness_key)).to eq SidekiqAlive.time_to_live
+    expect(redis.ttl(SidekiqAlive.config.liveness_key)).to eq SidekiqAlive.config.time_to_live
   end
 
   it "::alive?" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "sidekiq_alive"
+require "rspec-sidekiq"
 require 'mock_redis'
 
 # initialize server

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,9 @@ require "bundler/setup"
 require "sidekiq_alive"
 require "rspec-sidekiq"
 require "mock_redis"
+require 'rack/test'
+ENV['RACK_ENV'] = 'test'
 # initialize server
-SidekiqAlive::Server.start
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,7 @@
 require "bundler/setup"
 require "sidekiq_alive"
 require "rspec-sidekiq"
-require 'mock_redis'
-
+require "mock_redis"
 # initialize server
 SidekiqAlive::Server.start
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -4,11 +4,14 @@ RSpec.describe SidekiqAlive::Worker do
     n.perform
   end
 
+  specify { expect(described_class).to be_retryable(false) }
+  specify { expect(described_class).to be_processed_in(SidekiqAlive.queue_name) }
+
   it 'calls to main methods in SidekiqAlive' do
-    expect(described_class).to receive(:perform_in)#.with(instance_of(Integer))
+    expect(Sidekiq::Client).to receive(:enqueue_to_in).with(SidekiqAlive.queue_name, SidekiqAlive.time_to_live / 2, described_class)
     expect(SidekiqAlive).to receive(:store_alive_key).once
     n = 0
-    expect(SidekiqAlive).to   receive(:callback).once.and_return(proc { n = 2 })
+    expect(SidekiqAlive).to receive(:callback).once.and_return(proc { n = 2 })
     subject
     expect(n).to eq 2
   end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -20,23 +20,6 @@ RSpec.describe SidekiqAlive::Worker do
     expect(n).to eq 2
   end
 
-  it 'uses the configured values' do
-    SidekiqAlive.setup do |config|
-      config.queue_name = "sidekiq_alive"
-      config.queue_variant = 'hostname'
-    end
-
-    expect(described_class).to receive(:set)
-      .with(queue: 'sidekiq_alive-hostname')
-      .and_call_original
-    expect(described_class).to receive(:perform_in)
-      .with(SidekiqAlive.config.time_to_live / 2)
-      .and_call_original
-
-    allow(SidekiqAlive).to receive(:store_alive_key)
-    perform
-  end
-
   describe 'clean_old_queues' do
     subject(:clean_old_queues) { described_class.new.clean_old_queues }
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,18 +1,36 @@
 RSpec.describe SidekiqAlive::Worker do
-  subject do
-    n = described_class.new
-    n.perform
-  end
+  let(:worker_instance) { described_class.new }
+  subject(:perform){ worker_instance.perform }
 
   specify { expect(described_class).to be_retryable(false) }
-  specify { expect(described_class).to be_processed_in(SidekiqAlive.queue_name) }
+  specify { expect(described_class).to be_processed_in(SidekiqAlive.queue_with_variant) }
 
   it 'calls to main methods in SidekiqAlive' do
-    expect(Sidekiq::Client).to receive(:enqueue_to_in).with(SidekiqAlive.queue_name, SidekiqAlive.time_to_live / 2, described_class)
+    expect(Sidekiq::Client).to receive(:enqueue_to_in).with(SidekiqAlive.queue_with_variant,
+                                                            SidekiqAlive.time_to_live / 2,
+                                                            described_class)
+    expect(worker_instance).to receive(:clean_old_queues).once.and_call_original
     expect(SidekiqAlive).to receive(:store_alive_key).once
     n = 0
     expect(SidekiqAlive).to receive(:callback).once.and_return(proc { n = 2 })
-    subject
+    perform
     expect(n).to eq 2
+  end
+
+  it 'uses the configured values' do
+    SidekiqAlive.setup do |config|
+      config.queue_name = "sidekiq_alive"
+      config.queue_variant = 'hostname'
+    end
+
+    expect(Sidekiq::Client).to receive(:enqueue_to_in).with('sidekiq_alive-hostname',
+                                                            SidekiqAlive.time_to_live / 2,
+                                                            described_class)
+    allow(SidekiqAlive).to receive(:store_alive_key)
+    perform
+  end
+
+  xdescribe 'clean_old_queues' do
+
   end
 end


### PR DESCRIPTION
This approach tries to resolves the issue where multiple containers are
running sidekiq in a given cluster but each instance processing a single
queue that is specific to its instance and ensuring that the instance
only requeues on success to that same queue.