### PR TITLE
Limit the speed with which the worker is rescheduled if it was execut…

### DIFF
--- a/lib/sidekiq_alive/worker.rb
+++ b/lib/sidekiq_alive/worker.rb
@@ -11,7 +11,7 @@ module SidekiqAlive
         self.class.perform_in(config.time_to_live / 2, current_hostname)
       else
         # requeue for hostname to validate it's own liveness probe
-        self.class.perform_async(hostname)
+        self.class.perform_in(1.second, hostname)
       end
     end
 

--- a/lib/sidekiq_alive/worker.rb
+++ b/lib/sidekiq_alive/worker.rb
@@ -11,7 +11,7 @@ module SidekiqAlive
         self.class.perform_in(config.time_to_live / 2, current_hostname)
       else
         # requeue for hostname to validate it's own liveness probe
-        self.class.perform_in(1.second, hostname)
+        self.class.perform_in(1, hostname)
       end
     end
 


### PR DESCRIPTION
…ed on a different node

When a node is down, sidekiq_alive will immediately reschedule the worker job until the host is removed from the pool. This causes thousands of useless jobs to be executed each second in my cluster.

I propose to include a short wait between each retry in order to limit this behavior, by using perform_in 1 second instead of just use perform_async