### PR TITLE
Fix logging for Sidekiq 6

### DIFF
--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -75,7 +75,7 @@ module SidekiqAlive
   end
 
   def self.logger
-    Sidekiq::Logging.logger
+    Sidekiq.logger
   end
 
   def self.config


### PR DESCRIPTION
Hi! Gem in its current state does not work with Sidekiq 6. It's because of the logger `Sidekiq::Logging.logger`.

I changed it to `Sidekiq.logger` as a general method of accessing sidekiq logger. I tested it with sidekiq 5 and 6 versions.