### PR TITLE
Set default server to webrick, allow override

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ SidekiqAlive.setup do |config|
   #
   #   config.port = 7433
 
+  # ==> Rack server
+  # Web server used to run Sinatra
+  # default: webrick
+  #
+  #   config.server = 'puma'
+
   # ==> Liveness key
   # Key to be stored in Redis as probe of liveness
   # default: "SIDEKIQ::LIVENESS_PROBE_TIMESTAMP"

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -7,7 +7,8 @@ module SidekiqAlive
                   :time_to_live,
                   :callback,
                   :registered_instance_key,
-                  :queue_prefix
+                  :queue_prefix,
+                  :server
 
     def initialize
       set_defaults
@@ -20,6 +21,7 @@ module SidekiqAlive
       @callback = proc {}
       @registered_instance_key = 'SIDEKIQ_REGISTERED_INSTANCE'
       @queue_prefix = :sidekiq_alive
+      @server = 'webrick'
     end
 
     def registration_ttl

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -3,6 +3,7 @@ module SidekiqAlive
   class Server < Sinatra::Base
     set :bind, '0.0.0.0'
     set :port, -> { SidekiqAlive.config.port }
+    set :server, -> { SidekiqAlive.config.server }
 
     get '/' do
       if SidekiqAlive.alive?

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe SidekiqAlive::Server do
     before do
       ENV['SIDEKIQ_ALIVE_PORT'] = '4567'
       SidekiqAlive.config.set_defaults
+      SidekiqAlive.config.server = 'puma'
     end
 
     after do
@@ -34,6 +35,9 @@ RSpec.describe SidekiqAlive::Server do
     it 'respects the SIDEKIQ_ALIVE_PORT environment variable' do
       expect( described_class.port ).to eq '4567'
     end
-  end
 
+    it 'overrides the server correctly' do
+      expect( described_class.server ).to eq 'puma'
+    end
+  end
 end


### PR DESCRIPTION
The Sinatra server inside sidekiq_alive is picking up our project's default puma config, which has a lot of extra stuff (puma worker killer, runs 8 workers, starts up a node SSR server, etc). Running via webrick as a default seems like a reasonable option given this is a very simple, low-traffic http server.

I added an option to override the server if people need to.