### PR TITLE
Remove Sinatra dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: .
   specs:
-    sidekiq_alive (2.0.0)
+    sidekiq_alive (2.0.1)
       sidekiq
-      sinatra
 
 GEM
   remote: https://rubygems.org/
@@ -13,7 +12,6 @@ GEM
     diff-lcs (1.3)
     method_source (0.9.2)
     mock_redis (0.19.0)
-    mustermann (1.0.3)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -45,12 +43,6 @@ GEM
       rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
-    sinatra (2.0.5)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.5)
-      tilt (~> 2.0)
-    tilt (2.0.9)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -197,10 +197,18 @@ curl localhost:7433
 ```ruby
 SidekiqAlive.setup do |config|
   # ==> Server port
-  # Port to bind the server
+  # Port to bind the server.
+  # Can also be set with the environment variable SIDEKIQ_ALIVE_PORT.
   # default: 7433
   #
   #   config.port = 7433
+
+  # ==> Server path
+  # HTTP path to respond to.
+  # Can also be set with the environment variable SIDEKIQ_ALIVE_PATH.
+  # default: '/'
+  #
+  #   config.port = '/'
 
   # ==> Liveness key
   # Key to be stored in Redis as probe of liveness
@@ -234,6 +242,7 @@ SidekiqAlive.setup do |config|
 
   # ==> Rack server
   # Web server used to serve an HTTP response.
+  # Can also be set with the environment variable SIDEKIQ_ALIVE_SERVER.
   # default: 'webrick'
   #
   #    config.server = 'puma'

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bundle exec sidekiq
 
 ```
 curl localhost:7433
-#=> Alive!                                   
+#=> Alive!
 ```
 
 
@@ -202,6 +202,12 @@ SidekiqAlive.setup do |config|
   #
   #   config.port = 7433
 
+  # ==> Rack server
+  # Web server used to serve an HTTP response.
+  # default: 'webrick'
+  #
+  #   config.server = 'puma'
+
   # ==> Liveness key
   # Key to be stored in Redis as probe of liveness
   # default: "SIDEKIQ::LIVENESS_PROBE_TIMESTAMP"
@@ -227,7 +233,7 @@ SidekiqAlive.setup do |config|
   # ==> Queue Prefix
   # SidekiqAlive will run in a independent queue for each instance/replica
   # This queue name will be generated with: "#{queue_prefix}-#{hostname}.
-  # You can customize the prefix here. 
+  # You can customize the prefix here.
   # default: :sidekiq_alive
   #
   #    config.queue_prefix = :other

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ SidekiqAlive.setup do |config|
   # Can also be set with the environment variable SIDEKIQ_ALIVE_PATH.
   # default: '/'
   #
-  #   config.port = '/'
+  #   config.path = '/'
 
   # ==> Liveness key
   # Key to be stored in Redis as probe of liveness

--- a/README.md
+++ b/README.md
@@ -202,12 +202,6 @@ SidekiqAlive.setup do |config|
   #
   #   config.port = 7433
 
-  # ==> Rack server
-  # Web server used to serve an HTTP response.
-  # default: 'webrick'
-  #
-  #   config.server = 'puma'
-
   # ==> Liveness key
   # Key to be stored in Redis as probe of liveness
   # default: "SIDEKIQ::LIVENESS_PROBE_TIMESTAMP"
@@ -239,11 +233,10 @@ SidekiqAlive.setup do |config|
   #    config.queue_prefix = :other
 
   # ==> Rack server
-  # Web server used to run Sinatra
-  # default: webrick
+  # Web server used to serve an HTTP response.
+  # default: 'webrick'
   #
-  #   config.server = 'puma'
-
+  #    config.server = 'puma'
 end
 ```
 

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -27,6 +27,7 @@ module SidekiqAlive
       sq_config.on(:quiet) do
         SidekiqAlive.unregister_current_instance
       end
+
       sq_config.on(:shutdown) do
         Process.kill('TERM', @server_pid) unless @server_pid.nil?
         Process.wait(@server_pid) unless @server_pid.nil?

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -7,7 +7,8 @@ module SidekiqAlive
                   :time_to_live,
                   :callback,
                   :registered_instance_key,
-                  :queue_prefix
+                  :queue_prefix,
+                  :server
 
     def initialize
       set_defaults
@@ -20,6 +21,7 @@ module SidekiqAlive
       @callback = proc {}
       @registered_instance_key = 'SIDEKIQ_REGISTERED_INSTANCE'
       @queue_prefix = :sidekiq_alive
+      @server = 'webrick'
     end
 
     def registration_ttl

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -5,6 +5,7 @@ module SidekiqAlive
     include Singleton
 
     attr_accessor :port,
+                  :path,
                   :liveness_key,
                   :time_to_live,
                   :callback,
@@ -18,6 +19,7 @@ module SidekiqAlive
 
     def set_defaults
       @port = ENV['SIDEKIQ_ALIVE_PORT'] || 7433
+      @path = ENV['SIDEKIQ_ALIVE_PATH'] || '/'
       @liveness_key = 'SIDEKIQ::LIVENESS_PROBE_TIMESTAMP'
       @time_to_live = 10 * 60
       @callback = proc {}

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -6,7 +6,11 @@ module SidekiqAlive
   class Server
     class << self
       def run!
-        Rack::Handler.get(server).run(self, :Port => port, :Host => '0.0.0.0')
+        handler =  Rack::Handler.get(server)
+
+        Signal.trap('TERM') { handler.shutdown }
+
+        handler.run(self, Port: port, Host: '0.0.0.0')
       end
 
       def port

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -22,7 +22,9 @@ module SidekiqAlive
       end
 
       def call(env)
-        if SidekiqAlive.alive?
+        if Rack::Request.new(env).path != '/'
+          [404, {}, ['Not found']]
+        elsif SidekiqAlive.alive?
           [200, {}, ['Alive!']]
         else
           response = "Can't find the alive key"

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -2,21 +2,27 @@ require 'rack'
 
 module SidekiqAlive
   class Server
-    def self.run!
-      Rack::Handler::WEBrick.run(self, :Port => port, :Host => '0.0.0.0')
-    end
+    class << self
+      def run!
+        Rack::Handler.get(server).run(self, :Port => port, :Host => '0.0.0.0')
+      end
 
-    def self.port
-      SidekiqAlive.config.port
-    end
+      def port
+        SidekiqAlive.config.port
+      end
 
-    def self.call(env)
-      if SidekiqAlive.alive?
-        [200, {}, ['Alive!']]
-      else
-        response = "Can't find the alive key"
-        SidekiqAlive.logger.error(response)
-        [404, {}, [response]]
+      def server
+        SidekiqAlive.config.server
+      end
+
+      def call(env)
+        if SidekiqAlive.alive?
+          [200, {}, ['Alive!']]
+        else
+          response = "Can't find the alive key"
+          SidekiqAlive.logger.error(response)
+          [404, {}, [response]]
+        end
       end
     end
   end

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -17,12 +17,16 @@ module SidekiqAlive
         SidekiqAlive.config.port
       end
 
+      def path
+        SidekiqAlive.config.path
+      end
+
       def server
         SidekiqAlive.config.server
       end
 
       def call(env)
-        if Rack::Request.new(env).path != '/'
+        if Rack::Request.new(env).path != path
           [404, {}, ['Not found']]
         elsif SidekiqAlive.alive?
           [200, {}, ['Alive!']]

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -1,18 +1,22 @@
-require 'sinatra/base'
-module SidekiqAlive
-  class Server < Sinatra::Base
-    set :bind, '0.0.0.0'
-    set :port, -> { SidekiqAlive.config.port }
+require 'rack'
 
-    get '/' do
+module SidekiqAlive
+  class Server
+    def self.run!
+      Rack::Handler::WEBrick.run(self, :Port => port, :Host => '0.0.0.0')
+    end
+
+    def self.port
+      SidekiqAlive.config.port
+    end
+
+    def self.call(env)
       if SidekiqAlive.alive?
-        status 200
-        body 'Alive!'
+        [200, {}, ['Alive!']]
       else
         response = "Can't find the alive key"
         SidekiqAlive.logger.error(response)
-        status 404
-        body response
+        [404, {}, [response]]
       end
     end
   end

--- a/sidekiq_alive.gemspec
+++ b/sidekiq_alive.gemspec
@@ -37,5 +37,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-sidekiq", "~> 3.0"
   spec.add_development_dependency "mock_redis"
   spec.add_dependency "sidekiq"
-  spec.add_dependency "sinatra"
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe SidekiqAlive::Server do
       expect(last_response).not_to be_ok
       expect(last_response.body).to eq("Can't find the alive key")
     end
+
+    it 'responds not found on an unknown path' do
+      get '/unknown-path'
+      expect(last_response).not_to be_ok
+      expect(last_response.body).to eq("Not found")
+    end
   end
 
   describe 'SidekiqAlive setup port' do

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe SidekiqAlive::Server do
     before do
       ENV['SIDEKIQ_ALIVE_PORT'] = '4567'
       SidekiqAlive.config.set_defaults
+      SidekiqAlive.config.server = 'puma'
     end
 
     after do
@@ -32,8 +33,11 @@ RSpec.describe SidekiqAlive::Server do
     end
 
     it 'respects the SIDEKIQ_ALIVE_PORT environment variable' do
-      expect( described_class.port ).to eq '4567'
+      expect(described_class.port).to eq '4567'
+    end
+
+    it 'overrides the server correctly' do
+      expect(described_class.server).to eq 'puma'
     end
   end
-
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -59,4 +59,25 @@ RSpec.describe SidekiqAlive::Server do
       expect(described_class.server).to eq 'puma'
     end
   end
+
+  describe 'SidekiqAlive setup path' do
+    before do
+      ENV['SIDEKIQ_ALIVE_PATH'] = '/sidekiq-probe'
+      SidekiqAlive.config.set_defaults
+    end
+
+    after do
+      ENV['SIDEKIQ_ALIVE_PATH'] = nil
+    end
+
+    it 'respects the SIDEKIQ_ALIVE_PORT environment variable' do
+      expect(described_class.path).to eq '/sidekiq-probe'
+    end
+
+    it 'responds ok to the given path' do
+      allow(SidekiqAlive).to receive(:alive?) { true }
+      get '/sidekiq-probe'
+      expect(last_response).to be_ok
+    end
+  end
 end


### PR DESCRIPTION
In the same spirit as https://github.com/mperham/sidekiq/pull/3069, this PR removes the Sinatra dependency so as to make this gem slimmer.


- [x] <del>Also, allows choosing the web server as suggested in #34</del>
- [x] Also, allows choosing the path as suggested in #30