### PR TITLE
Prepend queue as the high priority queue (#31)

### DIFF
--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -9,7 +9,7 @@ module SidekiqAlive
     SidekiqAlive::Worker.sidekiq_options queue: current_queue
     Sidekiq.configure_server do |sq_config|
 
-      sq_config.options[:queues].prepend(current_queue)
+      sq_config.options[:queues].unshift(current_queue)
 
       sq_config.on(:startup) do
         SidekiqAlive.tap do |sa|

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -9,7 +9,7 @@ module SidekiqAlive
     SidekiqAlive::Worker.sidekiq_options queue: current_queue
     Sidekiq.configure_server do |sq_config|
 
-      sq_config.options[:queues] << current_queue
+      sq_config.options[:queues].prepend(current_queue)
 
       sq_config.on(:startup) do
         SidekiqAlive.tap do |sa|

--- a/spec/sidekiq_alive_spec.rb
+++ b/spec/sidekiq_alive_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe SidekiqAlive do
     expect(k.queue_prefix).to eq :other
   end
 
+  describe '::start' do
+    before do
+      allow(Sidekiq).to receive(:server?).and_return(true)
+    end
+
+    it 'prepend sidekiq alive queue' do
+      Sidekiq.options[:queues] = ['default']
+      SidekiqAlive.start
+
+      expect(Sidekiq.options[:queues].first).to eq(described_class.current_queue)
+    end
+  end
+
   before do
     allow(SidekiqAlive).to receive(:redis).and_return(MockRedis.new)
   end


### PR DESCRIPTION
This eliminates false negatives in workers with a large number of jobs (which does not allow the sidekiq_alive job to be processed)

Close #31 