### PR TITLE
Introduces host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ curl localhost:7433
 
 ```ruby
 SidekiqAlive.setup do |config|
+  # ==> Server host
+  # Host to bind the server.
+  # Can also be set with the environment variable SIDEKIQ_ALIVE_HOST.
+  # default: 0.0.0.0
+  #
+  #   config.host = 0.0.0.0
+
   # ==> Server port
   # Port to bind the server.
   # Can also be set with the environment variable SIDEKIQ_ALIVE_PORT.

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -4,7 +4,8 @@ module SidekiqAlive
   class Config
     include Singleton
 
-    attr_accessor :port,
+    attr_accessor :host,
+                  :port,
                   :path,
                   :liveness_key,
                   :time_to_live,
@@ -18,6 +19,7 @@ module SidekiqAlive
     end
 
     def set_defaults
+      @host = ENV['SIDEKIQ_ALIVE_HOST'] || '0.0.0.0'
       @port = ENV['SIDEKIQ_ALIVE_PORT'] || 7433
       @path = ENV['SIDEKIQ_ALIVE_PATH'] || '/'
       @liveness_key = 'SIDEKIQ::LIVENESS_PROBE_TIMESTAMP'

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -10,7 +10,11 @@ module SidekiqAlive
 
         Signal.trap('TERM') { handler.shutdown }
 
-        handler.run(self, Port: port, Host: '0.0.0.0')
+        handler.run(self, Port: port, Host: host)
+      end
+
+      def host
+        SidekiqAlive.config.host
       end
 
       def port

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe SidekiqAlive::Server do
     end
   end
 
+  describe 'SidekiqAlive setup host' do
+    before do
+      ENV['SIDEKIQ_ALIVE_HOST'] = '1.2.3.4'
+      SidekiqAlive.config.set_defaults
+    end
+
+    after do
+      ENV['SIDEKIQ_ALIVE_HOST'] = nil
+    end
+
+    it 'respects the SIDEKIQ_ALIVE_HOST environment variable' do
+      expect(described_class.host).to eq '1.2.3.4'
+    end
+  end
+
   describe 'SidekiqAlive setup port' do
     before do
       ENV['SIDEKIQ_ALIVE_PORT'] = '4567'

--- a/spec/sidekiq_alive_spec.rb
+++ b/spec/sidekiq_alive_spec.rb
@@ -3,6 +3,24 @@ RSpec.describe SidekiqAlive do
     expect(SidekiqAlive::VERSION).not_to be nil
   end
 
+  it 'configures the host from the #setup' do
+    described_class.setup do |config|
+      config.host = '1.2.3.4'
+    end
+
+    expect(described_class.config.host).to eq '1.2.3.4'
+  end
+
+  it 'configures the host from the SIDEKIQ_ALIVE_HOST ENV var' do
+    ENV['SIDEKIQ_ALIVE_HOST'] = '1.2.3.4'
+
+    SidekiqAlive.config.set_defaults
+
+    expect(described_class.config.host).to eq '1.2.3.4'
+
+    ENV['SIDEKIQ_ALIVE_HOST'] = nil
+  end
+
   it 'configures the port from the #setup' do
     described_class.setup do |config|
       config.port = 4567
@@ -23,6 +41,11 @@ RSpec.describe SidekiqAlive do
 
   it 'configurations behave as expected' do
     k = described_class.config
+
+    expect(k.host).to eq '0.0.0.0'
+    k.host = '1.2.3.4'
+    expect(k.host).to eq '1.2.3.4'
+
     expect(k.port).to eq 7433
     k.port = 4567
     expect(k.port).to eq 4567


### PR DESCRIPTION
I needed a way to customize the host option to make the server bind to a unix socket instead of `0.0.0.0`.