### PR TITLE
disable access log

### DIFF
--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -10,7 +10,7 @@ module SidekiqAlive
 
         Signal.trap('TERM') { handler.shutdown }
 
-        handler.run(self, Port: port, Host: host)
+        handler.run(self, Port: port, Host: '0.0.0.0', AccessLog: [])
       end
 
       def host


### PR DESCRIPTION
This patch disables WebRick's access logging. 