### PR TITLE
Replace unsafe Redis 'keys' command to recursive 'scan match'.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq_alive (2.0.6)
+    sidekiq_alive (2.1.0)
       sidekiq
 
 GEM
@@ -48,7 +48,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (> 1.16)
   mock_redis
   pry
   rack-test

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -52,7 +52,14 @@ module SidekiqAlive
   end
 
   def self.registered_instances
-    redis.keys("#{config.registered_instance_key}::*")
+    deep_scan("#{config.registered_instance_key}::*")
+  end
+
+  def self.deep_scan(keyword, keys = [], cursor = 0)
+    next_cursor, found_keys = *redis { |r| r }.scan(cursor, match: keyword)
+    keys += found_keys
+    return keys if next_cursor == "0" || found_keys.blank?
+    deep_scan(keyword, keys, next_cursor)
   end
 
   def self.purge_pending_jobs

--- a/sidekiq_alive.gemspec
+++ b/sidekiq_alive.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '> 1.16'
   spec.add_development_dependency 'mock_redis'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Using Redis 'keys' command in production is not proper and could cause i/o blocking while reading.
Created simple PR replacing unsafe part.

https://redis.io/commands/keys

Warning: consider KEYS as a command that should only be used in production environments with extreme care. It may ruin performance when it is executed against large databases. This command is intended for debugging and special operations, such as changing your keyspace layout. Don't use KEYS in your regular application code. If you're looking for a way to find keys in a subset of your keyspace, consider using SCAN or sets.