### PR TITLE
Pass logger to web server

### DIFF
--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -10,7 +10,7 @@ module SidekiqAlive
 
         Signal.trap('TERM') { handler.shutdown }
 
-        handler.run(self, Port: port, Host: '0.0.0.0', AccessLog: [])
+        handler.run(self, Port: port, Host: '0.0.0.0', AccessLog: [], Logger: SidekiqAlive.logger)
       end
 
       def host

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -10,7 +10,7 @@ module SidekiqAlive
 
         Signal.trap('TERM') { handler.shutdown }
 
-        handler.run(self, Port: port, Host: '0.0.0.0', AccessLog: [], Logger: SidekiqAlive.logger)
+        handler.run(self, Port: port, Host: host, AccessLog: [], Logger: SidekiqAlive.logger)
       end
 
       def host

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -7,6 +7,24 @@ RSpec.describe SidekiqAlive::Server do
 
   subject(:app) { described_class }
 
+  describe '#run!' do
+    subject { app.run! }
+
+    let(:fake_webrick) { double }
+
+    it 'runs the handler with sidekiq_alive logger' do
+      allow(Rack::Handler).to receive(:get).with('webrick').and_return(fake_webrick)
+
+      expect(fake_webrick).to receive(:run).with(
+        described_class,
+        hash_including(Logger: SidekiqAlive.logger)
+      )
+
+      subject
+    end
+
+  end
+
   describe 'responses' do
     it 'responds with success when the service is alive' do
       allow(SidekiqAlive).to receive(:alive?) { true }

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe SidekiqAlive::Server do
   describe '#run!' do
     subject { app.run! }
 
+    before { allow(Rack::Handler).to receive(:get).with('webrick').and_return(fake_webrick) }
+
     let(:fake_webrick) { double }
 
     it 'runs the handler with sidekiq_alive logger' do
-      allow(Rack::Handler).to receive(:get).with('webrick').and_return(fake_webrick)
-
       expect(fake_webrick).to receive(:run).with(
         described_class,
         hash_including(Logger: SidekiqAlive.logger)
@@ -23,6 +23,14 @@ RSpec.describe SidekiqAlive::Server do
       subject
     end
 
+    it 'runs the handler with host specified' do
+      expect(fake_webrick).to receive(:run).with(
+        described_class,
+        hash_including(host: '')
+      )
+
+      subject
+    end
   end
 
   describe 'responses' do


### PR DESCRIPTION
Webrick starts up with a log message that goes to the default logger, which creates an unformatted message in the logs with my configuration. This PR passes the SidekiqAlive.logger to Webbrick, so at least the log messages appear in the same stream

I also change the `host` to be the `#host` and not a fixed string (unsure if this change an intended)