### PR TITLE
fix: use queue prefix in sidekiq worker

### DIFF
--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -6,12 +6,12 @@ require 'sidekiq_alive/config'
 
 module SidekiqAlive
   def self.start
-    SidekiqAlive::Worker.sidekiq_options queue: current_queue
     Sidekiq.configure_server do |sq_config|
 
       sq_config.options[:queues].unshift(current_queue)
 
       sq_config.on(:startup) do
+        SidekiqAlive::Worker.sidekiq_options queue: current_queue
         SidekiqAlive.tap do |sa|
           sa.logger.info(banner)
           sa.register_current_instance
@@ -136,7 +136,7 @@ module SidekiqAlive
     Port: #{config.port}
     Time to live: #{config.time_to_live}s
     Current instance register key: #{current_instance_register_key}
-    Worker running on queue: #{@queue}
+    Worker running on queue: #{current_queue}
 
 
     starting ...

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -6,7 +6,7 @@ module SidekiqAlive
   class Server
     class << self
       def run!
-        handler =  Rack::Handler.get(server)
+        handler = Rack::Handler.get(server)
 
         Signal.trap('TERM') { handler.shutdown }
 


### PR DESCRIPTION
The current_queue variable will only reflect changes added in an initializer after the sidekiq startup hook 
fixes https://github.com/arturictus/sidekiq_alive/issues/42