### PR TITLE
Optional SIDEKIQ_ALIVE_HOSTNAME env var

### DIFF
--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -111,7 +111,7 @@ module SidekiqAlive
   end
 
   def self.hostname
-    ENV['HOSTNAME'] || 'HOSTNAME_NOT_SET'
+    ENV['SIDEKIQ_ALIVE_HOSTNAME'] || ENV['HOSTNAME'] || 'HOSTNAME_NOT_SET'
   end
 
   def self.shutdown_info


### PR DESCRIPTION
Referring to issue https://github.com/arturictus/sidekiq_alive/issues/25, running in docker container, somehow queues are not removed, so it might be helpful to have ability to set a permanent system-independent hostname value besides using a default hostname which is not permanent and being changed on a service restart and container recreation.