### PR TITLE
Remove deprecated options call on config

### DIFF
--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -9,7 +9,7 @@ module SidekiqAlive
     SidekiqAlive::Worker.sidekiq_options queue: current_queue
     Sidekiq.configure_server do |sq_config|
 
-      sq_config[:queues].unshift(current_queue)
+      (sq_config.respond_to?(:[]) ? sq_config[:queues] : sq_config.options[:queues]).unshift(current_queue)
 
       sq_config.on(:startup) do
         SidekiqAlive.tap do |sa|

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -9,7 +9,7 @@ module SidekiqAlive
     SidekiqAlive::Worker.sidekiq_options queue: current_queue
     Sidekiq.configure_server do |sq_config|
 
-      sq_config.options[:queues].unshift(current_queue)
+      sq_config[:queues].unshift(current_queue)
 
       sq_config.on(:startup) do
         SidekiqAlive.tap do |sa|


### PR DESCRIPTION
Usage of `config.options[:key] = value` is deprecated and generates 