### PR TITLE
Fix Sidekiq deprecation warning: use config[:key] instead of config.options[:key]

### DIFF
--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -9,7 +9,7 @@ module SidekiqAlive
     SidekiqAlive::Worker.sidekiq_options queue: current_queue
     Sidekiq.configure_server do |sq_config|
 
-      sq_config.options[:queues].unshift(current_queue)
+      sq_config[:queues].unshift(current_queue)
 
       sq_config.on(:startup) do
         SidekiqAlive.tap do |sa|


### PR DESCRIPTION
In the latest Sidekiq, there's the following deprecation notice:

> "config.options[:key] = value is deprecated, use config[:key] = value" sidekiq deprecation warning

This PR adds new syntax usage.