### PR TITLE
Only purge jobs pertaining to the current queue when 'SidekiqAlive::Worker' is terminated

### DIFF
--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -70,7 +70,7 @@ module SidekiqAlive
       jobs = if Helpers.sidekiq_5
         schedule_set.select { |job| job.klass == "SidekiqAlive::Worker" && job.queue == current_queue }
       else
-        schedule_set.scan('"class":"SidekiqAlive::Worker"')
+        schedule_set.scan('"class":"SidekiqAlive::Worker"').select { |job| job.queue == current_queue }
       end
       logger.info("[SidekiqAlive] Purging #{jobs.count} pending for #{hostname}")
       jobs.each(&:delete)

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -18,9 +18,11 @@ RSpec.describe(SidekiqAlive::Server) do
     it "runs the handler with sidekiq_alive logger, host and no access logs" do
       expect(fake_webrick).to(receive(:run).with(
         described_class,
-        hash_including(Logger: SidekiqAlive.logger,
-                       Host: "0.0.0.0",
-                       AccessLog: []),
+        hash_including(
+          Logger: SidekiqAlive.logger,
+          Host: "0.0.0.0",
+          AccessLog: [],
+        ),
       ))
 
       subject


### PR DESCRIPTION
In the latest release and using Sidekiq > 5, when a SidekiqAlive::Worker is shutdown/terminated via sidekiq_alive, the `unregister_current_instance` method ends up deleting jobs for ALL SidekiqAlive::Workers, not just its own.

This behavior was changed here https://github.com/arturictus/sidekiq_alive/commit/e686c88e7a1384e8cc122c408a2d746f209da3c4

I *don't think* this is the desired behavior.

Using the latest sidekiq_alive, I am seeing a sort of cascading effect of container restarts on Kubernetes. When one worker shuts down, whether it be to some job holding up the worker, or rolling out a new deployment, it starts a domino/looping effect of SidekiqAlive::Workers restarting and clearing all other SidekiqAlive jobs, which leads to more restarts, etc.

The problem boils down to the `purge_pending_jobs` method, which was converted to use a server side scan.

Old:

```rb
  def self.purge_pending_jobs
    # TODO:
    # Sidekiq 6 allows better way to find scheduled jobs:
    # https://github.com/mperham/sidekiq/wiki/API#scan
    scheduled_set = Sidekiq::ScheduledSet.new
    jobs = scheduled_set.select { |job| job.klass == 'SidekiqAlive::Worker' && job.queue == current_queue }
    logger.info("[SidekiqAlive] Purging #{jobs.count} pending for #{hostname}")
    jobs.each(&:delete)
    logger.info("[SidekiqAlive] Removing queue #{current_queue}")
    Sidekiq::Queue.new(current_queue).clear
  end
```

Latest release:

```rb
    def purge_pending_jobs
      schedule_set = Sidekiq::ScheduledSet.new
      jobs = if Helpers.sidekiq_5
        schedule_set.select { |job| job.klass == "SidekiqAlive::Worker" && job.queue == current_queue }
      else
        schedule_set.scan('"class":"SidekiqAlive::Worker"')
      end
      logger.info("[SidekiqAlive] Purging #{jobs.count} pending for #{hostname}")
      jobs.each(&:delete)

      logger.info("[SidekiqAlive] Removing queue #{current_queue}")
      Sidekiq::Queue.new(current_queue).clear
    end
```

The problem lies in this conditional:

```rb
jobs = if Helpers.sidekiq_5
        schedule_set.select { |job| job.klass == "SidekiqAlive::Worker" && job.queue == current_queue }
      else
        schedule_set.scan('"class":"SidekiqAlive::Worker"') # This will grab all instances, not just the current
      end
```