### PR TITLE
 undefined local variable or method `queue_prefix' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ SidekiqAlive.setup do |config|
   # default: proc {}
   #
   #    config.shutdown_callback = proc do
-  #      Sidekiq::Queue.all.find { |q| q.name == "#{queue_prefix}-#{SidekiqAlive.hostname}" }&.clear
+  #      Sidekiq::Queue.all.find { |q| q.name == "#{config.queue_prefix}-#{SidekiqAlive.hostname}" }&.clear
   #    end
 
   # ==> Queue Prefix


### PR DESCRIPTION
Readme typo:
when queue_prefix is used, it gives: undefined local variable or method `queue_prefix' for main:Object Added in config.queue_prefix