### PR TITLE
Use dedicated capsule for processing sidekiq-alive queue

### DIFF
--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -20,7 +20,7 @@ module SidekiqAlive
 
           if Helpers.sidekiq_7
             sq_config.capsule(CAPSULE_NAME) do |cap|
-              cap.concurrency = 1
+              cap.concurrency = 2
               cap.queues = [current_queue]
             end
           else

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -10,20 +10,21 @@ require "sidekiq_alive/redis"
 
 module SidekiqAlive
   HOSTNAME_REGISTRY = "sidekiq-alive-hostnames"
+  CAPSULE_NAME = "sidekiq-alive"
+
   class << self
     def start
       Sidekiq.configure_server do |sq_config|
         sq_config.on(:startup) do
           SidekiqAlive::Worker.sidekiq_options(queue: current_queue)
-          if Helpers.sidekiq_7
-            sq_config.queues
-          else
-            sq_config.respond_to?(:[]) ? sq_config[:queues] : sq_config.options[:queues]
-          end.unshift(current_queue)
 
-          # If no weight is set, webui might not show this queue for given instance/process.
           if Helpers.sidekiq_7
-            sq_config.default_capsule.weights[current_queue] = 1
+            sq_config.capsule(CAPSULE_NAME) do |cap|
+              cap.concurrency = 1
+              cap.queues = [current_queue]
+            end
+          else
+            (sq_config.respond_to?(:[]) ? sq_config[:queues] : sq_config.options[:queues]).unshift(current_queue)
           end
 
           logger.info(startup_info)

--- a/lib/sidekiq_alive/redis/base.rb
+++ b/lib/sidekiq_alive/redis/base.rb
@@ -28,7 +28,7 @@ module SidekiqAlive
       end
 
       def ttl(...)
-        Sidekiq.redis { |redis| redis.ttl(...) }
+        redis { |r| r.ttl(...) }
       end
     end
   end

--- a/lib/sidekiq_alive/redis/redis_client_gem.rb
+++ b/lib/sidekiq_alive/redis/redis_client_gem.rb
@@ -7,32 +7,45 @@ module SidekiqAlive
     # Wrapper for `redis-client` gem used by `sidekiq` > 7
     # https://github.com/redis-rb/redis-client
     class RedisClientGem < Base
+      def initialize
+        super
+
+        @capsule = Sidekiq.default_configuration.capsules[CAPSULE_NAME]
+      end
+
       def set(key, time:, ex:)
-        Sidekiq.redis { |redis| redis.call("SET", key, time, ex: ex) }
+        redis { |r| r.call("SET", key, time, ex: ex) }
       end
 
       def get(key)
-        Sidekiq.redis { |redis| redis.call("GET", key) }
+        redis { |r| r.call("GET", key) }
       end
 
       def zadd(set_key, ex, key)
-        Sidekiq.redis { |redis| redis.call("ZADD", set_key, ex, key) }
+        redis { |r| r.call("ZADD", set_key, ex, key) }
       end
 
       def zrange(set_key, start, stop)
-        Sidekiq.redis { |redis| redis.call("ZRANGE", set_key, start, stop) }
+        redis { |r| r.call("ZRANGE", set_key, start, stop) }
       end
 
       def zrangebyscore(set_key, min, max)
-        Sidekiq.redis { |redis| redis.call("ZRANGEBYSCORE", set_key, min, max) }
+        redis { |r| r.call("ZRANGEBYSCORE", set_key, min, max) }
       end
 
       def zrem(set_key, key)
-        Sidekiq.redis { |redis| redis.call("ZREM", set_key, key) }
+        redis { |r| r.call("ZREM", set_key, key) }
       end
 
       def delete(key)
-        Sidekiq.redis { |redis| redis.call("DEL", key) }
+        redis { |r| r.call("DEL", key) }
+      end
+
+      private
+
+      def redis(&block)
+        # Default to Sidekiq.redis if capsule is not configured yet but redis adapter is accessed
+        (@capsule || Sidekiq).redis(&block)
       end
     end
   end

--- a/lib/sidekiq_alive/redis/redis_gem.rb
+++ b/lib/sidekiq_alive/redis/redis_gem.rb
@@ -8,37 +8,37 @@ module SidekiqAlive
     # https://github.com/redis/redis-rb
     class RedisGem < Base
       def set(key, time:, ex:)
-        redis.set(key, time, ex: ex)
+        redis { |r| r.set(key, time, ex: ex) }
       end
 
       def get(key)
-        redis.get(key)
+        redis { |r| r.get(key) }
       end
 
       def zadd(set_key, ex, key)
-        redis.zadd(set_key, ex, key)
+        redis { |r| r.zadd(set_key, ex, key) }
       end
 
       def zrange(set_key, start, stop)
-        redis.zrange(set_key, start, stop)
+        redis { |r| r.zrange(set_key, start, stop) }
       end
 
       def zrangebyscore(set_key, min, max)
-        redis.zrangebyscore(set_key, min, max)
+        redis { |r| r.zrangebyscore(set_key, min, max) }
       end
 
       def zrem(set_key, key)
-        redis.zrem(set_key, key)
+        redis { |r| r.zrem(set_key, key) }
       end
 
       def delete(key)
-        redis.del(key)
+        redis { |r| r.del(key) }
       end
 
       private
 
-      def redis
-        Sidekiq.redis { |redis| redis }
+      def redis(&block)
+        Sidekiq.redis(&block)
       end
     end
   end


### PR DESCRIPTION
This introduces a separate capsule for handling sidekiq alive queue and makes it sequential because we don't really need to process multiple alive jobs in parallel.

* I think it improves the design by not mutating "default" capsule
* Uses capsule local connection pool
* It should solve an issue I encountered in my own application, more details, more context here: https://gitlab.com/dependabot-gitlab/dependabot/-/issues/293#note_1408148243. TLDR; basically if an app fills in all threads that are configured for sidekiq and those jobs are long running, we can end up where alive job is not picked up for long enough and start reporting app as unhealthy.