### PR TITLE
proposed SIDEKIQ_ALIVE_CONCURRENCY configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,14 @@ SidekiqAlive.setup do |config|
   # default: 'webrick'
   #
   #    config.server = 'puma'
+
+  # ==> Concurrency
+  # The maximum number of Redis connections requested for the SidekiqAlive pool.
+  # Can also be set with the environment variable SIDEKIQ_ALIVE_CONCURRENCY.
+  # NOTE: only effects Sidekiq 7 or greater.
+  # default: 2
+  #
+  #    config.concurrency = 3
 end
 ```
 

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -20,7 +20,7 @@ module SidekiqAlive
 
           if Helpers.sidekiq_7
             sq_config.capsule(CAPSULE_NAME) do |cap|
-              cap.concurrency = 2
+              cap.concurrency = config.concurrency
               cap.queues = [current_queue]
             end
           else

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -15,7 +15,8 @@ module SidekiqAlive
                   :server,
                   :custom_liveness_probe,
                   :logger,
-                  :shutdown_callback
+                  :shutdown_callback,
+                  :concurrency
 
     def initialize
       set_defaults
@@ -33,6 +34,7 @@ module SidekiqAlive
       @server = ENV.fetch("SIDEKIQ_ALIVE_SERVER", "webrick")
       @custom_liveness_probe = proc { true }
       @shutdown_callback = proc {}
+      @concurrency = Integer(ENV.fetch("SIDEKIQ_ALIVE_CONCURRENCY", 2), exception: false) || 2
     end
 
     def registration_ttl

--- a/spec/sidekiq_alive_spec.rb
+++ b/spec/sidekiq_alive_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe(SidekiqAlive) do
       ENV["SIDEKIQ_ALIVE_PORT"] = nil
     end
 
+    it "configures the concurrency from the SIDEKIQ_ALIVE_CONCURRENCY ENV var" do
+      ENV["SIDEKIQ_ALIVE_CONCURRENCY"] = "3"
+
+      SidekiqAlive.config.set_defaults
+
+      expect(described_class.config.concurrency).to(eq(3))
+
+      ENV["SIDEKIQ_ALIVE_CONCURRENCY"] = nil
+    end
+
     it "configurations behave as expected" do
       k = described_class.config
 


### PR DESCRIPTION
Redis connection timeout issue in sidekiq_alive (occasionally) during shutdown of sidekiq (Issue #100)