### PR TITLE
Implement quite mode for alive web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,10 @@ SidekiqAlive.setup do |config|
   #    config.callback = proc { Net::HTTP.get("https://status.com/ping") }
 
   # ==> Shutdown callback
-  # When sidekiq process is shutting down, you can perform some action, like cleaning up created queue
+  # When sidekiq process is shutting down, you can perform some arbitrary action.
   # default: proc {}
   #
-  #    config.shutdown_callback = proc do
-  #      Sidekiq::Queue.all.find { |q| q.name == "#{config.queue_prefix}-#{SidekiqAlive.hostname}" }&.clear
-  #    end
+  #    config.shutdown_callback = proc { puts "Sidekiq is shutting down" }
 
   # ==> Queue Prefix
   # SidekiqAlive will run in a independent queue for each instance/replica

--- a/README.md
+++ b/README.md
@@ -276,6 +276,16 @@ SidekiqAlive.setup do |config|
   #
   #    config.server = 'puma'
 
+  # ==> Quiet mode timeout in seconds
+  # When sidekiq is shutting down, all job processing is stopped. This includes alive key update job. In case of
+  # long running jobs, alive key can expire before the job is finished. To avoid this, web server is set in to quiet mode
+  # and is returning 200 OK for healthcheck requests. To avoid infinite quiet mode in case sidekiq process is stuck in shutdown,
+  # timeout can be set. After timeout is reached, web server resumes normal operations and will return unhealthy status in case
+  # alive key is expired or purged from redis.
+  # default: 180
+  #
+  #    config.quiet_timeout = 300
+
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ SidekiqAlive.setup do |config|
   #    config.server = 'puma'
 
   # ==> Quiet mode timeout in seconds
-  # When sidekiq is shutting down, all job processing is stopped. This includes alive key update job. In case of
+  # When sidekiq is shutting down, the Sidekiq process stops pulling jobs from the queue. This includes alive key update job. In case of
   # long running jobs, alive key can expire before the job is finished. To avoid this, web server is set in to quiet mode
   # and is returning 200 OK for healthcheck requests. To avoid infinite quiet mode in case sidekiq process is stuck in shutdown,
   # timeout can be set. After timeout is reached, web server resumes normal operations and will return unhealthy status in case

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -28,9 +28,7 @@ module SidekiqAlive
           end
 
           logger.info("[SidekiqAlive] #{startup_info}")
-
           register_current_instance
-
           store_alive_key
           # Passing the hostname argument it's only for debugging enqueued jobs
           SidekiqAlive::Worker.perform_async(hostname)

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -47,7 +47,9 @@ module SidekiqAlive
 
         sq_config.on(:shutdown) do
           remove_queue
-          redis.zrem(HOSTNAME_REGISTRY, current_instance_register_key)
+          # make sure correct redis pool is used
+          # sidekiq will terminate non internal capsules
+          Redis.adapter("internal").zrem(HOSTNAME_REGISTRY, current_instance_register_key)
           config.shutdown_callback.call
         end
       end

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -40,6 +40,7 @@ module SidekiqAlive
         sq_config.on(:quiet) do
           logger.info("[SidekiqAlive] #{shutdown_info}")
           purge_pending_jobs
+          # set web server to quiet mode
           @server&.quiet!
         end
 

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -45,7 +45,7 @@ module SidekiqAlive
 
         sq_config.on(:shutdown) do
           remove_queue
-          # make sure correct redis pool is used
+          # make sure correct redis connection pool is used
           # sidekiq will terminate non internal capsules
           Redis.adapter("internal").zrem(HOSTNAME_REGISTRY, current_instance_register_key)
           config.shutdown_callback.call

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -16,7 +16,8 @@ module SidekiqAlive
                   :logger,
                   :shutdown_callback,
                   :concurrency,
-                  :server
+                  :server,
+                  :quiet_timeout
 
     def initialize
       set_defaults
@@ -35,6 +36,7 @@ module SidekiqAlive
       @shutdown_callback = proc {}
       @concurrency = Integer(ENV.fetch("SIDEKIQ_ALIVE_CONCURRENCY", 2), exception: false) || 2
       @server = ENV.fetch("SIDEKIQ_ALIVE_SERVER", nil)
+      @quiet_timeout = Integer(ENV.fetch("SIDEKIQ_ALIVE_QUIET_TIMEOUT", 180), exception: false) || 180
     end
 
     def registration_ttl

--- a/lib/sidekiq_alive/redis.rb
+++ b/lib/sidekiq_alive/redis.rb
@@ -3,8 +3,8 @@
 module SidekiqAlive
   module Redis
     class << self
-      def adapter
-        Helpers.sidekiq_7 ? Redis::RedisClientGem.new : Redis::RedisGem.new
+      def adapter(capsule = nil)
+        Helpers.sidekiq_7 ? Redis::RedisClientGem.new(capsule) : Redis::RedisGem.new
       end
     end
   end

--- a/lib/sidekiq_alive/redis/redis_client_gem.rb
+++ b/lib/sidekiq_alive/redis/redis_client_gem.rb
@@ -8,7 +8,7 @@ module SidekiqAlive
     # https://github.com/redis-rb/redis-client
     class RedisClientGem < Base
       def initialize(capsule = nil)
-        super
+        super()
 
         @capsule = Sidekiq.default_configuration.capsules[capsule || CAPSULE_NAME]
       end

--- a/lib/sidekiq_alive/redis/redis_client_gem.rb
+++ b/lib/sidekiq_alive/redis/redis_client_gem.rb
@@ -7,10 +7,10 @@ module SidekiqAlive
     # Wrapper for `redis-client` gem used by `sidekiq` > 7
     # https://github.com/redis-rb/redis-client
     class RedisClientGem < Base
-      def initialize
+      def initialize(capsule = nil)
         super
 
-        @capsule = Sidekiq.default_configuration.capsules[CAPSULE_NAME]
+        @capsule = Sidekiq.default_configuration.capsules[capsule || CAPSULE_NAME]
       end
 
       def set(key, time:, ex:)

--- a/lib/sidekiq_alive/server/base.rb
+++ b/lib/sidekiq_alive/server/base.rb
@@ -16,7 +16,7 @@ module SidekiqAlive
 
       def configure_shutdown
         Kernel.at_exit do
-          SidekiqAlive.logger.info("Shutting down SidekiqAlive web server")
+          logger.info("Shutting down SidekiqAlive web server")
           Process.kill(SHUTDOWN_SIGNAL, @server_pid) unless @server_pid.nil?
           Process.wait(@server_pid) unless @server_pid.nil?
         end

--- a/lib/sidekiq_alive/server/base.rb
+++ b/lib/sidekiq_alive/server/base.rb
@@ -14,7 +14,7 @@ module SidekiqAlive
       private
 
       def configure_shutdown
-        at_exit do
+        Kernel.at_exit do
           SidekiqAlive.logger.info("Shutting down SidekiqAlive web server")
           Process.kill(SHUTDOWN_SIGNAL, @server_pid) unless @server_pid.nil?
           Process.wait(@server_pid) unless @server_pid.nil?

--- a/lib/sidekiq_alive/server/base.rb
+++ b/lib/sidekiq_alive/server/base.rb
@@ -16,9 +16,11 @@ module SidekiqAlive
 
       def configure_shutdown
         Kernel.at_exit do
+          next if @server_pid.nil?
+
           logger.info("Shutting down SidekiqAlive web server")
-          Process.kill(SHUTDOWN_SIGNAL, @server_pid) unless @server_pid.nil?
-          Process.wait(@server_pid) unless @server_pid.nil?
+          Process.kill(SHUTDOWN_SIGNAL, @server_pid)
+          Process.wait(@server_pid)
         end
       end
 

--- a/lib/sidekiq_alive/server/base.rb
+++ b/lib/sidekiq_alive/server/base.rb
@@ -4,17 +4,28 @@ module SidekiqAlive
   module Server
     module Base
       SHUTDOWN_SIGNAL = "TERM"
+      QUIET_SIGNAL = "USR1"
 
-      def shutdown!
-        SidekiqAlive.logger.info("Shutting down SidekiqAlive web server")
-        Process.kill(SHUTDOWN_SIGNAL, @server_pid) unless @server_pid.nil?
-        Process.wait(@server_pid) unless @server_pid.nil?
+      def quiet!
+        Process.kill("USR1", @server_pid) unless @server_pid.nil?
       end
 
       private
 
+      def configure_shutdown
+        at_exit do
+          SidekiqAlive.logger.info("Shutting down SidekiqAlive web server")
+          Process.kill(SHUTDOWN_SIGNAL, @server_pid) unless @server_pid.nil?
+          Process.wait(@server_pid) unless @server_pid.nil?
+        end
+      end
+
       def configure_shutdown_signal(&block)
         Signal.trap(SHUTDOWN_SIGNAL, &block)
+      end
+
+      def configure_quiet_signal(&block)
+        Signal.trap(QUIET_SIGNAL, &block)
       end
 
       def host

--- a/lib/sidekiq_alive/server/base.rb
+++ b/lib/sidekiq_alive/server/base.rb
@@ -6,8 +6,9 @@ module SidekiqAlive
       SHUTDOWN_SIGNAL = "TERM"
       QUIET_SIGNAL = "USR1"
 
+      # set web server to quiet mode
       def quiet!
-        Process.kill("USR1", @server_pid) unless @server_pid.nil?
+        Process.kill(QUIET_SIGNAL, @server_pid) unless @server_pid.nil?
       end
 
       private

--- a/lib/sidekiq_alive/server/base.rb
+++ b/lib/sidekiq_alive/server/base.rb
@@ -8,6 +8,7 @@ module SidekiqAlive
 
       # set web server to quiet mode
       def quiet!
+        logger.info("[SidekiqAlive] Setting web server to quiet mode")
         Process.kill(QUIET_SIGNAL, @server_pid) unless @server_pid.nil?
       end
 

--- a/lib/sidekiq_alive/server/default.rb
+++ b/lib/sidekiq_alive/server/default.rb
@@ -16,11 +16,11 @@ module SidekiqAlive
             # stop is wrapped in a thread because gserver calls synchrnonize which raises an error when in trap context
             configure_shutdown_signal { Thread.new { @server.stop } }
             configure_quiet_signal { @server.quiet! }
-            configure_shutdown
 
             @server.start
             @server.join
           end
+          configure_shutdown
           logger.info("[SidekiqAlive] Web server started in subprocess with pid #{@server_pid}")
 
           self

--- a/lib/sidekiq_alive/server/default.rb
+++ b/lib/sidekiq_alive/server/default.rb
@@ -40,7 +40,7 @@ module SidekiqAlive
           return logger.warn("[SidekiqAlive] Path '#{req.path}' not found")
         end
 
-        if @quiet
+        if quiet?
           res.status = 200
           res.body = "Server is shutting down"
           return logger.debug("[SidekiqAlive] Server in quiet mode, skipping alive key lookup!")
@@ -64,12 +64,16 @@ module SidekiqAlive
       end
 
       def quiet!
-        @quiet = true
+        @quiet = Time.now
       end
 
       private
 
       attr_reader :path
+
+      def quiet?
+        @quiet && (@quiet - Time.now) < SidekiqAlive.config.quiet_timeout
+      end
     end
   end
 end

--- a/lib/sidekiq_alive/server/rack.rb
+++ b/lib/sidekiq_alive/server/rack.rb
@@ -14,10 +14,10 @@ module SidekiqAlive
             @handler = handler
             configure_shutdown_signal { @handler.shutdown }
             configure_quiet_signal { @quiet = Time.now }
-            configure_shutdown
 
             @handler.run(self, Port: port, Host: host, AccessLog: [], Logger: logger)
           end
+          configure_shutdown
 
           self
         end

--- a/spec/server/default_spec.rb
+++ b/spec/server/default_spec.rb
@@ -53,4 +53,16 @@ RSpec.describe(SidekiqAlive::Server::Default) do
       expect(@last_response.code).to(eq("200"))
     end
   end
+
+  context "with quiet mode" do
+    before do
+      server.quiet!
+    end
+
+    it "responds with success and server is shutting down message" do
+      get "/"
+      expect(@last_response.code).to(eq("200"))
+      expect(@last_response.body).to(eq("Server is shutting down"))
+    end
+  end
 end

--- a/spec/server/rack_spec.rb
+++ b/spec/server/rack_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe(SidekiqAlive::Server::Rack) do
 
   subject(:app) { described_class }
 
+  before do
+    described_class.instance_variable_set(:@quiet, nil)
+  end
+
   context "with default configuration" do
     it "responds with success when the service is alive" do
       allow(SidekiqAlive).to(receive(:alive?) { true })
@@ -50,6 +54,18 @@ RSpec.describe(SidekiqAlive::Server::Rack) do
 
       get "/sidekiq-probe"
       expect(last_response).to(be_ok)
+    end
+  end
+
+  context "with quiet mode" do
+    before do
+      described_class.instance_variable_set(:@quiet, Time.now)
+    end
+
+    it "responds with success and server is shutting down message" do
+      get "/"
+      expect(last_response).to(be_ok)
+      expect(last_response.body).to(eq("Server is shutting down"))
     end
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -13,50 +13,64 @@ around_config = proc do |example|
   ENV["SIDEKIQ_ALIVE_PATH"] = nil
 end
 
-RSpec.describe(SidekiqAlive::Server) do
+RSpec.describe(SidekiqAlive::Server, :aggregate_failures) do
   subject(:app) { described_class }
 
   let(:pid) { Random.rand(1000) }
 
   before do
-    allow(Process).to(receive(:fork).and_return(pid))
+    allow(Process).to(receive(:fork).and_yield.and_return(pid))
     allow(Process).to(receive(:kill))
     allow(Process).to(receive(:wait))
     allow(Signal).to(receive(:trap))
+    allow(Kernel).to(receive(:at_exit))
   end
 
   context "with default server" do
-    let(:fake_server) { instance_double(SidekiqAlive::Server::Default, start: nil, stop: nil, join: nil) }
+    let(:fake_server) do
+      instance_double(
+        SidekiqAlive::Server::Default,
+        start: nil,
+        stop: nil,
+        join: nil,
+        quiet!: nil,
+      )
+    end
 
     before do
       allow(SidekiqAlive::Server::Default).to(receive(:new).and_return(fake_server))
       allow(Thread).to(receive(:new).and_yield)
+
+      app.run!
     end
 
     context "with default config" do
-      it "starts server with default arguments and traps shutdown", :aggregate_failures do
-        app.run!
+      it "starts server with default arguments and configures lifecycle" do
+        expect(SidekiqAlive::Server::Default).to(have_received(:new).with(7433, "0.0.0.0", "/"))
+        expect(fake_server).to(have_received(:start))
+        expect(fake_server).to(have_received(:join))
+      end
 
-        expect(Process).to(have_received(:fork)) do |&block|
-          block.call
+      it "configures signals" do
+        expect(Signal).to(have_received(:trap).with("TERM")) do |&arg|
+          arg.call
 
-          expect(SidekiqAlive::Server::Default).to(have_received(:new).with(7433, "0.0.0.0", "/"))
-          expect(fake_server).to(have_received(:start))
-          expect(fake_server).to(have_received(:join))
-          expect(Signal).to(have_received(:trap).with("TERM")) do |&arg|
-            arg.call
+          expect(fake_server).to(have_received(:stop))
+        end
+        expect(Signal).to(have_received(:trap).with("USR1")) do |&arg|
+          arg.call
 
-            expect(fake_server).to(have_received(:stop))
-          end
+          expect(fake_server).to(have_received(:quiet!))
         end
       end
 
-      it "shuts down server" do
-        server = app.run!
-        server.shutdown!
+      it "configures shutdown" do
+        allow(Kernel).to(receive(:at_exit)) do |&arg|
+          arg.call
 
-        expect(Process).to(have_received(:kill).with("TERM", pid))
-        expect(Process).to(have_received(:wait).with(pid))
+          expect(Process).to(have_received(:kill).with("TERM", pid))
+          expect(Process).to(have_received(:wait).with(pid))
+        end
       end
     end
 
@@ -64,13 +78,7 @@ RSpec.describe(SidekiqAlive::Server) do
       around(&around_config)
 
       it "starts with updated configuration" do
-        app.run!
-
-        expect(Process).to(have_received(:fork)) do |&block|
-          block.call
-
-          expect(SidekiqAlive::Server::Default).to(have_received(:new).with(4567, "1.2.3.4", "/health"))
-        end
+        expect(SidekiqAlive::Server::Default).to(have_received(:new).with(4567, "1.2.3.4", "/health"))
       end
     end
   end
@@ -84,35 +92,41 @@ RSpec.describe(SidekiqAlive::Server) do
       SidekiqAlive.config.set_defaults
 
       allow(handler).to(receive(:get).and_return(fake_server))
+      SidekiqAlive::Server::Rack.instance_variable_set(:@quiet, nil)
+
+      app.run!
     end
 
     after { ENV["SIDEKIQ_ALIVE_SERVER"] = nil }
 
     context "with default config" do
       it "starts server with default arguments and traps shutdown", :aggregate_failures do
-        app.run!
+        expect(handler).to(have_received(:get).with("webrick"))
+        expect(fake_server).to(have_received(:run).with(
+          SidekiqAlive::Server::Rack, Port: 7433, Host: "0.0.0.0", AccessLog: [], Logger: SidekiqAlive.logger
+        ))
+      end
 
-        expect(Process).to(have_received(:fork)) do |&block|
-          block.call
+      it "configures signals" do
+        expect(Signal).to(have_received(:trap).with("TERM")) do |&arg|
+          arg.call
 
-          expect(handler).to(have_received(:get).with("webrick"))
-          expect(fake_server).to(have_received(:run).with(
-            SidekiqAlive::Server::Rack, Port: 7433, Host: "0.0.0.0", AccessLog: [], Logger: SidekiqAlive.logger
-          ))
-          expect(Signal).to(have_received(:trap).with("TERM")) do |&arg|
-            arg.call
+          expect(fake_server).to(have_received(:shutdown))
+        end
+        expect(Signal).to(have_received(:trap).with("USR1")) do |&arg|
+          arg.call
 
-            expect(fake_server).to(have_received(:shutdown))
-          end
+          expect(SidekiqAlive::Server::Rack.instance_variable_get(:@quiet)).to(eq(true))
         end
       end
 
-      it "shuts down server" do
-        server = app.run!
-        server.shutdown!
+      it "configures shutdown" do
+        allow(Kernel).to(receive(:at_exit)) do |&arg|
+          arg.call
 
-        expect(Process).to(have_received(:kill).with("TERM", pid))
-        expect(Process).to(have_received(:wait).with(pid))
+          expect(Process).to(have_received(:kill).with("TERM", pid))
+          expect(Process).to(have_received(:wait).with(pid))
+        end
       end
     end
 
@@ -120,15 +134,9 @@ RSpec.describe(SidekiqAlive::Server) do
       around(&around_config)
 
       it "starts with updated configuration" do
-        app.run!
-
-        expect(Process).to(have_received(:fork)) do |&block|
-          block.call
-
-          expect(fake_server).to(have_received(:run).with(
-            SidekiqAlive::Server::Rack, Port: 4567, Host: "1.2.3.4", AccessLog: [], Logger: SidekiqAlive.logger
-          ))
-        end
+        expect(fake_server).to(have_received(:run).with(
+          SidekiqAlive::Server::Rack, Port: 4567, Host: "1.2.3.4", AccessLog: [], Logger: SidekiqAlive.logger
+        ))
       end
     end
   end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe(SidekiqAlive::Server, :aggregate_failures) do
         expect(Signal).to(have_received(:trap).with("USR1")) do |&arg|
           arg.call
 
-          expect(SidekiqAlive::Server::Rack.instance_variable_get(:@quiet)).to(eq(true))
+          expect(SidekiqAlive::Server::Rack.instance_variable_get(:@quiet)).to(be_instance_of(Time))
         end
       end
 


### PR DESCRIPTION
This PR implements suggestion from https://github.com/arturictus/sidekiq_alive/issues/85 to gracefully handle extended sidekiq shutdowns. Additional improvements and fixes are added as well.

* Implement "quite" mode when sidekiq is shutting down. While web server is in "quite" mode, it will return healthy status by default because alive key is not updated during this period
* Add a configurable timeout for quite mode so server is not stuck as healthy indefinitely if sidekiq process fails to shut down
* Attempt to fix timeout errors by not using `sidekiq-alive` capsule connections during the shutdown. Related to: https://github.com/arturictus/sidekiq_alive/issues/100
* Don't call callbacks and cleanup operations twice, purge jobs on quite, cleanup queues and call shutdown callback only on shutdown

Closes #85, #100, #105