### PR TITLE
Remove orphaned queues

### DIFF
--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -42,5 +42,9 @@ module SidekiqAlive
     def registration_ttl
       @registration_ttl || time_to_live * 3
     end
+
+    def worker_interval
+      time_to_live / 2
+    end
   end
 end

--- a/lib/sidekiq_alive/worker.rb
+++ b/lib/sidekiq_alive/worker.rb
@@ -12,8 +12,9 @@ module SidekiqAlive
 
       # Writes the liveness in Redis
       write_living_probe
+      remove_orphaned_queues
       # schedules next living probe
-      self.class.perform_in(config.time_to_live / 2, current_hostname)
+      self.class.perform_in(config.worker_interval, current_hostname)
     end
 
     def write_living_probe
@@ -27,6 +28,17 @@ module SidekiqAlive
       rescue StandardError
         nil
       end
+    end
+
+    # Removes orphaned Sidekiq queues left behind by unexpected instance shutdowns (e.g., due to OOM)
+    def remove_orphaned_queues
+      # If the worker isn't executed within this window, the lifeness key expires
+      latency_threshold = config.time_to_live - config.worker_interval
+      Sidekiq::Queue.all
+        .filter { |q| q.name.start_with?(config.queue_prefix.to_s) }
+        .filter { |q| q.latency > latency_threshold }
+        .filter { |q| q.size == 1 }
+        .each(&:clear)
     end
 
     def current_hostname

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe(SidekiqAlive::Config) do
+  subject(:config) { described_class.instance }
+
+  describe "#worker_interval" do
+    it "less than ttl" do
+      expect(config.worker_interval).to(satisfy { |i| i < config.time_to_live })
+    end
+  end
+end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -1,25 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe(SidekiqAlive::Worker) do
-  context "When being executed in the same instance" do
-    subject do
-      described_class.new.perform
-    end
+  subject(:perform_inline) do
+    described_class.perform_inline
+  end
 
+  context "When being executed in the same instance" do
     it "stores alive key and requeues it self" do
       SidekiqAlive.register_current_instance
       expect(described_class).to(receive(:perform_in))
       n = 0
       SidekiqAlive.config.callback = proc { n = 2 }
-      subject
+      perform_inline
       expect(n).to(eq(2))
       expect(SidekiqAlive.alive?).to(be(true))
     end
   end
+
   context "custom liveness probe" do
-    subject do
-      described_class.new.perform
-    end
     it "on error" do
       expect(described_class).not_to(receive(:perform_in))
       n = 0
@@ -28,21 +26,40 @@ RSpec.describe(SidekiqAlive::Worker) do
         raise "Nop"
       end
       begin
-        subject
+        perform_inline
       rescue StandardError
         nil
       end
       expect(n).to(eq(2))
       expect(SidekiqAlive.alive?).to(be(false))
     end
+
     it "on success" do
       expect(described_class).to(receive(:perform_in))
       n = 0
       SidekiqAlive.config.custom_liveness_probe = proc { n = 2 }
-      subject
+      perform_inline
 
       expect(n).to(eq(2))
       expect(SidekiqAlive.alive?).to(be(true))
+    end
+  end
+
+  describe "orphaned queues removal" do
+    it "removes orphaned queues" do
+      queue = instance_double(Sidekiq::Queue, name: "notifications", latency: 10_000, size: 1, clear: nil)
+      imposter_queue = instance_double(Sidekiq::Queue, name: "sidekiq-aliveness", latency: 10_000, size: 2, clear: nil)
+      orphaned_queue = instance_double(Sidekiq::Queue, name: "sidekiq-alive-foo", latency: 350, size: 1, clear: nil)
+      orphaning_queue = instance_double(Sidekiq::Queue, name: "sidekiq-alive-bar", latency: 200, size: 1, clear: nil)
+
+      allow(Sidekiq::Queue).to(receive(:all).and_return([queue, imposter_queue, orphaned_queue, orphaning_queue]))
+
+      perform_inline
+
+      expect(queue).not_to(have_received(:clear))
+      expect(imposter_queue).not_to(have_received(:clear))
+      expect(orphaned_queue).to(have_received(:clear))
+      expect(orphaning_queue).not_to(have_received(:clear))
     end
   end
 end


### PR DESCRIPTION
If an instance is terminated unexpectedly (e.g., due to OOM), `quiet` and `shutdown` events are not processed. This lives "orphaned" sidekiq alive queues.

In our case those orphaned queues mess up with latency alarms.

I suggest to incorporate the orphaned queues removal into the worker.