### PR TITLE
Always remove stale jobs and queues on start

### DIFF
--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -30,6 +30,11 @@ module SidekiqAlive
           logger.info("[SidekiqAlive] #{startup_info}")
           register_current_instance
           store_alive_key
+
+          # Purge remaining jobs from previous instances
+          purge_pending_jobs
+          remove_queue
+
           # Passing the hostname argument it's only for debugging enqueued jobs
           SidekiqAlive::Worker.perform_async(hostname)
           @server = SidekiqAlive::Server.run!

--- a/lib/sidekiq_alive/worker.rb
+++ b/lib/sidekiq_alive/worker.rb
@@ -38,7 +38,7 @@ module SidekiqAlive
       Sidekiq::Queue.all
         .filter { |q| q.name.start_with?(config.queue_prefix.to_s) }
         .filter { |q| q.latency > latency_threshold }
-        .filter { |q| q.size == 1 && q.all? { |job| job.klass == self.class.name } }
+        .filter { |q| q.all? { |job| job.klass == self.class.name } }
         .each(&:clear)
     end
 

--- a/spec/sidekiq_alive_spec.rb
+++ b/spec/sidekiq_alive_spec.rb
@@ -185,6 +185,38 @@ RSpec.describe(SidekiqAlive) do
 
         expect(queues.first).to(eq("#{queue_prefix}-test-hostname"))
       end
+
+      context "with previously existing jobs" do
+        let(:current_queue) { SidekiqAlive.current_queue }
+        around do |example|
+          Sidekiq::Testing.disable! { example.run }
+        end
+
+        before do
+          SidekiqAlive::Worker.set(queue: current_queue).perform_async(SidekiqAlive.hostname)
+          SidekiqAlive::Worker.set(queue: current_queue).perform_async(SidekiqAlive.hostname)
+          SidekiqAlive::Worker.set(queue: current_queue).perform_in(300, SidekiqAlive.hostname)
+          SidekiqAlive::Worker.set(queue: current_queue).perform_in(300, SidekiqAlive.hostname)
+        end
+
+        def scheduled_jobs(queue)
+          if SidekiqAlive::Helpers.sidekiq_5?
+            Sidekiq::ScheduledSet.new.select { |job| job.klass == "SidekiqAlive::Worker" && job.queue == queue }
+          else
+            Sidekiq::ScheduledSet.new.scan('"class":"SidekiqAlive::Worker"').select { |job| job.queue == queue }
+          end
+        end
+
+        it "purges old jobs from queue and scheduled set" do
+          expect(Sidekiq::Queue.new(current_queue)).to(have_attributes(size: 2))
+          expect(scheduled_jobs(current_queue).count).to(eq(2))
+
+          SidekiqAlive.start
+
+          expect(Sidekiq::Queue.new(current_queue)).to(have_attributes(size: 1))
+          expect(scheduled_jobs(current_queue).count).to(eq(0))
+        end
+      end
     end
   end
 end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe(SidekiqAlive::Worker) do
       queue = instance_double(Sidekiq::Queue, name: "notifications", latency: 10_000, size: 1, clear: nil)
       orphaning_queue = instance_double(Sidekiq::Queue, name: "sidekiq-alive-bar", latency: 200, size: 1, clear: nil)
 
-      orphaned_queue = instance_double(Sidekiq::Queue, name: "sidekiq-alive-foo", latency: 350, size: 1, clear: nil)
+      orphaned_queue = instance_double(Sidekiq::Queue, name: "sidekiq-alive-foo", latency: 350, size: 2, clear: nil)
       alive_job = instance_double(Sidekiq::JobRecord, klass: "SidekiqAlive::Worker")
-      allow(orphaned_queue).to(receive(:all?).and_yield(alive_job))
+      allow(orphaned_queue).to(receive(:all?).and_yield(alive_job).and_yield(alive_job))
 
       imposter_queue = instance_double(Sidekiq::Queue, name: "sidekiq-aliveness", latency: 10_000, size: 1, clear: nil)
       job = instance_double(Sidekiq::JobRecord, klass: "AlivenessWorker")


### PR DESCRIPTION
Currently, a new `SidekiqAlive::Worker` job is pushed every time server is started. In cases such as pod restarts, this creates a new job chain, so with each restart the queue is filling up with more jobs, at least in some circumstances. This both creates extra load and prevents removal of queues left over from previous pods.

This PR mitigates this in both places:
- Remove jobs left behind in current queue on startup.
- Clean up stale queues even if they have several jobs.

Relates to #143.

Non-obvious behavior that comes from #143 and is still relevant:
- An empty stale queue with no scheduled jobs will not get cleaned up.
- It takes some time until stale queues are cleaned up: all scheduled jobs need to be enqueued, and then a fresh job needs to see high latency.